### PR TITLE
#12：Access Token / Refresh Tokenの永続化、#13：アプリ名変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GOOGLE_CALENDAR_ID="(Please paste your own Google Calendar calendar ID)"
 ```bash
 npm i -g pnpm
 pnpm i
-pnpm run search "meeting"
+pnpm run hunt "meeting"
 ```
 
 ### Execution result

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# schedule-checker
+# google-calendar-event-searcher
 
 - This application retrieves and displays appointments from Google Calendar.
 - Node.js is required for operation.
@@ -20,7 +20,7 @@ GOOGLE_CALENDAR_ID="(Please paste your own Google Calendar calendar ID)"
 ```bash
 npm i -g pnpm
 pnpm i
-pnpm run schedule "meeting"
+pnpm run search "meeting"
 ```
 
 ### Execution result

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# calendar-event-searcher
+# timehunt
 
 - This application retrieves and displays appointments from Google Calendar.
 - Node.js is required for operation.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# google-calendar-event-searcher
+# calendar-event-searcher
 
 - This application retrieves and displays appointments from Google Calendar.
 - Node.js is required for operation.

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@
 ```.env
 GOOGLE_CLIENT_ID="(Get it from Google Cloud Console)"
 GOOGLE_CLIENT_SECRET="(Get it from Google Cloud Console)"
-GOOGLE_ACCESS_TOKEN="(Obtained at the first execution of this application)"
-GOOGLE_REFRESH_TOKEN="(Obtained at the first execution of this application)"
 GOOGLE_CALENDAR_ID="(Please paste your own Google Calendar calendar ID)"
 ```
 
 ### Execution command
 
 ```bash
-schedule "meeting"
+npm i -g pnpm
+pnpm i
+pnpm run schedule "meeting"
 ```
 
 ### Execution result

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -22,7 +22,7 @@ GOOGLE_CALENDAR_ID="(ご自身のGoogleカレンダーのカレンダーIDを貼
 ```bash
 npm i -g pnpm
 pnpm i
-pnpm run search "会議"
+pnpm run hunt "会議"
 ```
 
 ### 実行結果

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-# schedule-checker
+# google-calendar-event-searcher
 
 - Googleカレンダーから予定を取得して表示するアプリです。
 - 動作にはNode.jsが必要です。
@@ -20,7 +20,9 @@ GOOGLE_CALENDAR_ID="(ご自身のGoogleカレンダーのカレンダーIDを貼
 ### 実行コマンド
 
 ```bash
-schedule "meeting"
+npm i -g pnpm
+pnpm i
+pnpm run search "会議"
 ```
 
 ### 実行結果

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-# calendar-event-searcher
+# timehunt
 
 - Googleカレンダーから予定を取得して表示するアプリです。
 - 動作にはNode.jsが必要です。

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-# google-calendar-event-searcher
+# calendar-event-searcher
 
 - Googleカレンダーから予定を取得して表示するアプリです。
 - 動作にはNode.jsが必要です。

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "schedule-checker",
+  "name": "google-calendar-event-searcher",
   "version": "1.0.0",
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "schedule": "'ts-node' src/index.ts",
+    "search": "'ts-node' src/index.ts",
     "build": "tsc"
   },
   "packageManager": "pnpm@8.6.12",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "calendar-event-searcher",
+  "name": "timehunt",
   "version": "1.0.0",
   "description": "",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "search": "'ts-node' src/index.ts",
+    "hunt": "'ts-node' src/index.ts",
     "build": "tsc"
   },
   "packageManager": "pnpm@8.6.12",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-calendar-event-searcher",
+  "name": "calendar-event-searcher",
   "version": "1.0.0",
   "description": "",
   "main": "index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,6 @@ const SCOPE = ['https://www.googleapis.com/auth/calendar.readonly'];
 const JSON_DIR_PATH = join(homedir(), '.conf', 'timehunt', 'cache');
 const JSON_FILE_PATH = join(JSON_DIR_PATH, 'token.json');
 
-const oauth2Client = new OAuth2Client(
-  googleClientID,
-  googleClientSecret,
-  REDIRECT_URL
-);
-
 const getAccessToken = (oauth2Client: OAuth2Client) => {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -47,6 +41,12 @@ const getAccessToken = (oauth2Client: OAuth2Client) => {
 };
 
 const listEvents = async () => {
+  const oauth2Client = new OAuth2Client(
+    googleClientID,
+    googleClientSecret,
+    REDIRECT_URL
+  );
+
   const calendar = google.calendar({
     version: 'v3',
     auth: oauth2Client,

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,8 @@ const listEvents = async () => {
       console.log('No upcoming events found.');
     }
   } catch (error) {
-    console.log(error);
+    await getCredentials(oauth2Client);
+    await listEvents();
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,10 @@ const getAccessToken = (oauth2Client: OAuth2Client) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     oauth2Client.getToken(code, (err: any, tokens: any) => {
       const saveDirPath = join(homedir(), '.conf', 'schedule-checker', 'cache');
-      console.log('Token has been issued.');
+      const filePath = join(saveDirPath, 'token.json');
       fs.mkdirSync(saveDirPath, { recursive: true });
-      fs.writeFileSync(
-        `${join(saveDirPath, 'token.json')}`,
-        JSON.stringify(tokens)
-      );
+      fs.writeFileSync(filePath, JSON.stringify(tokens));
+      console.log('Token has been issued: ', filePath);
     });
     rl.close();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import { google, calendar_v3 } from 'googleapis';
 import { parseISO, isSameHour, format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { getEnv } from './lib/env';
+import fs from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 
 const {
   googleClientID,
@@ -33,17 +36,21 @@ const getAccessToken = (oauth2Client: OAuth2Client) => {
     scope: SCOPE,
   });
 
-  console.log('Please open the URL on the right with your browser: ', url);
+  console.log('Please open the URL on the right with your browser:\n', url);
   rl.question('Please paste the code shown: ', (code: string) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     oauth2Client.getToken(code, (err: any, tokens: any) => {
+      const saveDirPath = join(homedir(), '.conf', 'schedule-checker', 'cache');
       console.log('Token has been issued.');
-      console.log(tokens);
-      console.log('Please keep the above information in a safe place.');
+      fs.mkdirSync(saveDirPath, { recursive: true });
+      fs.writeFileSync(
+        `${join(saveDirPath, 'token.json')}`,
+        JSON.stringify(tokens)
+      );
     });
     rl.close();
   });
-}
+};
 
 const listEvents = async () => {
   const calendar = google.calendar({

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,7 @@ const listEvents = async () => {
     ? getCredentialsFromJSON(JSON_FILE_PATH)
     : await getCredentials(oauth2Client);
   if (credentials) {
-    oauth2Client.setCredentials({
-      access_token: credentials.access_token,
-      refresh_token: credentials.refresh_token,
-    });
+    oauth2Client.setCredentials(credentials);
   }
 
   const calendar = google.calendar({

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,7 @@ const { googleClientID, googleClientSecret, googleCalendarID } = getEnv();
 
 const REDIRECT_URL = 'urn:ietf:wg:oauth:2.0:oob';
 const SCOPE = ['https://www.googleapis.com/auth/calendar.readonly'];
-const JSON_DIR_PATH = join(
-  homedir(),
-  '.conf',
-  'calendar-event-searcher',
-  'cache'
-);
+const JSON_DIR_PATH = join(homedir(), '.conf', 'timehunt', 'cache');
 const JSON_FILE_PATH = join(JSON_DIR_PATH, 'token.json');
 
 const oauth2Client = new OAuth2Client(

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,19 +143,12 @@ const getTimeStr = (start: string, end: string) => {
   }
 };
 
-const isJson = (data: string) => {
-  try {
-    JSON.parse(data);
-  } catch (error) {
-    return false;
-  }
-  return true;
-};
-
 const getCredentialsFromJSON = (JSONFilePath: string) => {
   const buff = fs.readFileSync(JSONFilePath, 'utf8');
-  if (isJson(buff)) {
+  try {
     return JSON.parse(buff) as Credentials;
+  } catch (error) {
+    return undefined;
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,12 @@ const { googleClientID, googleClientSecret, googleCalendarID } = getEnv();
 
 const REDIRECT_URL = 'urn:ietf:wg:oauth:2.0:oob';
 const SCOPE = ['https://www.googleapis.com/auth/calendar.readonly'];
-const JSON_DIR_PATH = join(homedir(), '.conf', 'schedule-checker', 'cache');
+const JSON_DIR_PATH = join(
+  homedir(),
+  '.conf',
+  'google-calendar-event-searcher',
+  'cache'
+);
 const JSON_FILE_PATH = join(JSON_DIR_PATH, 'token.json');
 
 const oauth2Client = new OAuth2Client(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { OAuth2Client } from 'google-auth-library';
+import { Credentials, OAuth2Client } from 'google-auth-library';
 import readline from 'readline';
 import { google, calendar_v3 } from 'googleapis';
 import { parseISO, isSameHour, format } from 'date-fns';
@@ -34,12 +34,14 @@ const getAccessToken = (oauth2Client: OAuth2Client) => {
 
   console.log('Please open the URL on the right with your browser:\n', url);
   rl.question('Please paste the code shown: ', (code: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    oauth2Client.getToken(code, (err: any, tokens: any) => {
-      fs.mkdirSync(JSON_DIR_PATH, { recursive: true });
-      fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(tokens));
-      console.log('Token has been issued: ', JSON_FILE_PATH);
-    });
+    oauth2Client.getToken(
+      code,
+      (err, tokens: Credentials | null | undefined) => {
+        fs.mkdirSync(JSON_DIR_PATH, { recursive: true });
+        fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(tokens));
+        console.log('Token has been issued: ', JSON_FILE_PATH);
+      }
+    );
     rl.close();
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,28 +15,32 @@ const SCOPE = ['https://www.googleapis.com/auth/calendar.readonly'];
 const JSON_DIR_PATH = join(homedir(), '.conf', 'timehunt', 'cache');
 const JSON_FILE_PATH = join(JSON_DIR_PATH, 'token.json');
 
-const getAccessToken = (oauth2Client: OAuth2Client) => {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
+const getAccessToken = async (oauth2Client: OAuth2Client) => {
+  return new Promise<Credentials | undefined>((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
 
-  const url = oauth2Client.generateAuthUrl({
-    access_type: 'offline',
-    scope: SCOPE,
-  });
+    const url = oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: SCOPE,
+    });
 
-  console.log('Please open the URL on the right with your browser:\n', url);
-  rl.question('Please paste the code shown: ', (code: string) => {
-    oauth2Client.getToken(
-      code,
-      (err, tokens: Credentials | null | undefined) => {
-        fs.mkdirSync(JSON_DIR_PATH, { recursive: true });
-        fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(tokens));
-        console.log('Token has been issued: ', JSON_FILE_PATH);
-      }
-    );
-    rl.close();
+    console.log('Please open the URL on the right with your browser:\n', url);
+    rl.question('Please paste the code shown: ', (code: string) => {
+      oauth2Client.getToken(code, (_err, tokens) => {
+        if (tokens) {
+          fs.mkdirSync(JSON_DIR_PATH, { recursive: true });
+          fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(tokens));
+          console.log('Token has been issued: ', JSON_FILE_PATH);
+          resolve(tokens);
+        } else {
+          resolve(undefined);
+        }
+      });
+      rl.close();
+    });
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const SCOPE = ['https://www.googleapis.com/auth/calendar.readonly'];
 const JSON_DIR_PATH = join(
   homedir(),
   '.conf',
-  'google-calendar-event-searcher',
+  'calendar-event-searcher',
   'cache'
 );
 const JSON_FILE_PATH = join(JSON_DIR_PATH, 'token.json');

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,14 +1,8 @@
-import "dotenv/config"
+import 'dotenv/config';
 
-export const getEnv = () =>
-{
-  const {
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET,
-    GOOGLE_ACCESS_TOKEN,
-    GOOGLE_REFRESH_TOKEN,
-    GOOGLE_CALENDAR_ID,
-  } = process.env;
+export const getEnv = () => {
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALENDAR_ID } =
+    process.env;
 
   if (!GOOGLE_CLIENT_ID) {
     throw Error('Please set the environment variable GOOGLE_CLIENT_ID.');
@@ -23,8 +17,6 @@ export const getEnv = () =>
   return {
     googleClientID: GOOGLE_CLIENT_ID,
     googleClientSecret: GOOGLE_CLIENT_SECRET,
-    googleAccessToken: GOOGLE_ACCESS_TOKEN,
-    googleRefreshToken: GOOGLE_REFRESH_TOKEN,
     googleCalendarID: GOOGLE_CALENDAR_ID,
   };
 };


### PR DESCRIPTION
## 関連issue
- #12 
- #13 

## 背景
- アクセストークンおよびリフレッシュトークンが期限切れになるケースの対応
- npmjsで被らない名前にしたい

## 対応内容
- [x] アクセストークンとリフレッシュトークンは `~/.conf/timehunt/cache/token.json` から取得する
- [x] アクセストークンとリフレッシュトークンが無効だった場合、または、`~/.conf/timehunt/cache/token.json` が存在しない場合、getAccessToken（現getCredentials） を実行する
- [x] README.mdの更新
- [x] アプリ名の更新（命名：`timehunt` ）
- [x] コマンド名の更新（命名： `hunt` ）