### PR TITLE
fixコマンドのサブコマンド化

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "start": "node ./dist/src/index.js",
-    "timehunt": "'ts-node' src/index.ts",
+    "hunt": "'ts-node' src/index.ts 'hunt'",
+    "fix": "'ts-node' src/index.ts 'fix'",
     "build": "tsc"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timehunt",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,15 @@
 {
   "name": "timehunt",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {
     "start": "node ./dist/src/index.js",
-    "hunt": "'ts-node' src/index.ts",
-    "fix": "'ts-node' src/fix.ts",
+    "timehunt": "'ts-node' src/index.ts",
     "build": "tsc"
   },
   "bin": {
-    "timehunt": "dist/src/index.js",
-    "timehunt_fix": "dist/src/fix.js"
+    "timehunt": "dist/src/index.js"
   },
   "packageManager": "pnpm@8.6.12",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timehunt",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timehunt",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node ./dist/src/index.js",
     "hunt": "'ts-node' src/index.ts 'hunt'",
     "fix": "'ts-node' src/index.ts 'fix'",
+    "help": "'ts-node' src/index.ts 'help'",
     "build": "tsc"
   },
   "bin": {

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -34,17 +34,17 @@ const yes = async (question: string): Promise<boolean> => {
   });
 };
 
-export const fixCommandHandler = async () => {
+export const fixCommandHandler = async (
+  beforeEventName: string,
+  afterEventName: string,
+  dateTimeRange: string
+) => {
   const oauth2Client = await initializeOAuth2Client();
 
   if (process.argv.length !== 6) {
     console.log('Arguments are wrong.');
     exit();
   }
-
-  const beforeEventName = process.argv[3];
-  const afterEventName = process.argv[4];
-  const dateTimeRange = process.argv[5];
 
   try {
     const beforeEvents = await getEvents(oauth2Client, beforeEventName);
@@ -79,10 +79,8 @@ export const fixCommandHandler = async () => {
     }
   } catch (error) {
     await getCredentials(oauth2Client);
-    await fixCommandHandler();
+    await fixCommandHandler(beforeEventName, afterEventName, dateTimeRange);
   } finally {
     rl.close();
   }
 };
-
-fixCommandHandler();

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -37,14 +37,14 @@ const yes = async (question: string): Promise<boolean> => {
 export const fixCommandHandler = async () => {
   const oauth2Client = await initializeOAuth2Client();
 
-  if (process.argv.length !== 5) {
+  if (process.argv.length !== 6) {
     console.log('Arguments are wrong.');
     exit();
   }
 
-  const beforeEventName = process.argv[2];
-  const afterEventName = process.argv[3];
-  const dateTimeRange = process.argv[4];
+  const beforeEventName = process.argv[3];
+  const afterEventName = process.argv[4];
+  const dateTimeRange = process.argv[5];
 
   try {
     const beforeEvents = await getEvents(oauth2Client, beforeEventName);

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -34,7 +34,7 @@ const yes = async (question: string): Promise<boolean> => {
   });
 };
 
-const fixCommandHandler = async () => {
+export const fixCommandHandler = async () => {
   const oauth2Client = await initializeOAuth2Client();
 
   if (process.argv.length !== 5) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,0 +1,11 @@
+import * as packageJson from '../package.json';
+
+export const displayHowToUse = () => {
+  return `Version ${packageJson.version}
+    Usage: timehunt [command] [flags]
+
+    Manage your events:
+      hunt                  Displays a list of events with the name you specify.
+      fix                   Delete all [old_events_name] and create an event named [new_events_name] with a date and time of [new_schedule_datetime].
+  `;
+};

--- a/src/help.ts
+++ b/src/help.ts
@@ -2,10 +2,11 @@ import * as packageJson from '../package.json';
 
 export const displayHowToUse = () => {
   return `Version ${packageJson.version}
-    Usage: timehunt [command] [flags]
+    Usage: timehunt hunt <events_name>
+           timehunt fix <old_events_name> <new_events_name> <new_schedule_datetime>
 
     Manage your events:
-      hunt                  Displays a list of events with the name you specify.
-      fix                   Delete all [old_events_name] and create an event named [new_events_name] with a date and time of [new_schedule_datetime].
+      hunt                  Displays a list of events with the <events_name> you specify.
+      fix                   Delete all <old_events_name> and create an event named <new_events_name> with a date and time of <new_schedule_datetime>.
   `;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   displayDateTimeRange,
   groupEventsByDate,
 } from './util/dateTimeUtility';
+import { fixCommandHandler } from './fix';
 
 const listEvents = async () => {
   const oauth2Client = await initializeOAuth2Client();
@@ -29,4 +30,8 @@ const listEvents = async () => {
   }
 };
 
-listEvents();
+if (process.argv[2] === 'fix') {
+  fixCommandHandler();
+} else {
+  listEvents();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from './util/dateTimeUtility';
 import { fixCommandHandler } from './fix';
 import { exit } from 'process';
+import { displayHowToUse } from './help';
 
 const listEvents = async (eventName: string) => {
   const oauth2Client = await initializeOAuth2Client();
@@ -37,15 +38,16 @@ const listEvents = async (eventName: string) => {
   }
 };
 
-const HOW_TO_USE_HUNT =
-  'Displays a list of events with the name you specify.\n  timehunt hunt [events_name]';
-const HOW_TO_USE_FIX =
-  'Delete all [old_events_name] and create an event named [new_events_name] with a date and time of [new_schedule_datetime].\n  timehunt fix [old_events_name] [new_events_name] [new_schedule_datetime]';
-
-process.argv[2] === 'hunt'
-  ? listEvents(process.argv[3])
-  : process.argv[2] === 'fix'
-    ? fixCommandHandler(process.argv[3], process.argv[4], process.argv[5])
-    : console.log(
-        `How to use timehunt:\n${HOW_TO_USE_HUNT}\n${HOW_TO_USE_FIX}`
-      );
+switch (process.argv[2]) {
+  case 'hunt':
+    listEvents(process.argv[3]);
+    break;
+  case 'fix':
+    fixCommandHandler(process.argv[3], process.argv[4], process.argv[5]);
+    break;
+  case 'help':
+    console.log(displayHowToUse());
+    break;
+  default:
+    console.log(displayHowToUse());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,8 @@ switch (process.argv[2]) {
     fixCommandHandler(process.argv[3], process.argv[4], process.argv[5]);
     break;
   case 'help':
-    console.log(displayHowToUse());
-    break;
+  case '-h':
+  case '--help':
   default:
     console.log(displayHowToUse());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,30 +8,44 @@ import {
   groupEventsByDate,
 } from './util/dateTimeUtility';
 import { fixCommandHandler } from './fix';
+import { exit } from 'process';
 
-const listEvents = async () => {
+const listEvents = async (eventName: string) => {
   const oauth2Client = await initializeOAuth2Client();
 
   try {
-    const events = await getEvents(oauth2Client, process.argv[2]); // Get event name from command line argument
+    const events = await getEvents(oauth2Client, eventName);
     if (events) {
-      console.log('Upcoming events:');
       const groupedEvents = groupEventsByDate(events);
-      await displayDateTimeRange(groupedEvents);
-      if (events.length > 10) {
-        console.log('The number of events exceeds 10.');
+      if (groupedEvents.length > 0) {
+        console.log('Upcoming events:');
+        await displayDateTimeRange(groupedEvents);
+        if (events.length > 10) {
+          console.log('The number of events exceeds 10.');
+        }
+      } else {
+        console.log('No upcoming events found.');
       }
     } else {
-      console.log('No upcoming events found.');
+      console.log('Could not found event.');
     }
   } catch (error) {
     await getCredentials(oauth2Client);
-    await listEvents();
+    await listEvents(eventName);
+  } finally {
+    exit();
   }
 };
 
-if (process.argv[2] === 'fix') {
-  fixCommandHandler();
-} else {
-  listEvents();
-}
+const HOW_TO_USE_HUNT =
+  'Displays a list of events with the name you specify.\n  timehunt hunt [events_name]';
+const HOW_TO_USE_FIX =
+  'Delete all [old_events_name] and create an event named [new_events_name] with a date and time of [new_schedule_datetime].\n  timehunt fix [old_events_name] [new_events_name] [new_schedule_datetime]';
+
+process.argv[2] === 'hunt'
+  ? listEvents(process.argv[3])
+  : process.argv[2] === 'fix'
+    ? fixCommandHandler(process.argv[3], process.argv[4], process.argv[5])
+    : console.log(
+        `How to use timehunt:\n${HOW_TO_USE_HUNT}\n${HOW_TO_USE_FIX}`
+      );

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,4 +50,5 @@ switch (process.argv[2]) {
   case '--help':
   default:
     console.log(displayHowToUse());
+    exit();
 }


### PR DESCRIPTION
## 対応内容
- [x] fixコマンドのサブコマンド化
```timehunt fix <old_events_name> <new_events_name> <new_schedule_datetime>```
- [x] helpコマンドの追加（`-h`, `--help`, 第二引数が間違っている場合でも表示）
```
Version x.x.x
    Usage: timehunt hunt <events_name>
           timehunt fix <old_events_name> <new_events_name> <new_schedule_datetime>

    Manage your events:
      hunt                  Displays a list of events with the <events_name> you specify.
      fix                   Delete all <old_events_name> and create an event named <new_events_name> with a date and time of <new_schedule_datetime>.
```